### PR TITLE
Docker fedora 31 support

### DIFF
--- a/roles/docker/meta/main.yml
+++ b/roles/docker/meta/main.yml
@@ -12,8 +12,8 @@ galaxy_info:
   platforms:
     - name: Fedora
       versions:
-        - all
         - 30
+        - 31
     - name: EL
       versions:
         - 7

--- a/roles/docker/molecule/vagrant-fedora-31/molecule.yml
+++ b/roles/docker/molecule/vagrant-fedora-31/molecule.yml
@@ -1,0 +1,28 @@
+---
+dependency:
+  name: galaxy
+  role-file: requirements.yml
+driver:
+  name: vagrant
+  provider:
+    name: virtualbox
+lint:
+  name: yamllint
+platforms:
+  - name: docker-fedora-31
+    box: fedora/31-cloud-base
+provisioner:
+  name: ansible
+  log: True
+  playbooks:
+    vagrant:
+      prepare: ../resources/playbooks/prepare.yml
+    converge: ../resources/playbooks/playbook.yml
+    verify: ../resources/playbooks/verify.yml
+  lint:
+    name: ansible-lint
+verifier:
+  name: goss
+  directory: ../resources/tests
+  lint:
+    name: yamllint

--- a/roles/docker/tasks/install_Fedora.yml
+++ b/roles/docker/tasks/install_Fedora.yml
@@ -12,8 +12,8 @@
 
 - name: Setup yum repository
   get_url:
-    url: https://download.docker.com/linux/centos/docker-ce.repo
-    checksum: "sha256:6650718e0fe5202ae7618521f695d43a8bc051c539d7570f0edbfa5b4916f218"
+    url: https://download.docker.com/linux/fedora/docker-ce.repo
+    checksum: "sha256:3af973c1f2e16a032a11074eb22b440894ad4936c9ca86b666f8cf8342b7bea7"
     dest: /etc/yum.repos.d/docker-ce.repo
     mode: '0644'
   become: yes

--- a/roles/docker/tasks/main.yml
+++ b/roles/docker/tasks/main.yml
@@ -5,7 +5,7 @@
   when: ansible_facts['distribution'] == "CentOS" and ansible_facts['distribution_version']|int <= 7
 
 - include: install_Fedora.yml
-  when: ansible_facts['distribution'] == "Fedora" and ansible_facts['distribution_version']|int == 30
+  when: ansible_facts['distribution'] == "Fedora" and ansible_facts['distribution_version']|int >= 30
 
 - include: install_Ubuntu.yml
   when: ansible_facts['distribution'] == "Ubuntu" and ansible_facts['distribution_version'] == "18.04"


### PR DESCRIPTION
Tested docker install over Fedora 31.

fixes #5 

Note that fedora users shall activate CGroups V1 before using this cookbook