### PR TITLE
Update VirtualBox role for RHEL 8

### DIFF
--- a/roles/virtualbox/molecule/vagrant-rhel-8/molecule.yml
+++ b/roles/virtualbox/molecule/vagrant-rhel-8/molecule.yml
@@ -11,6 +11,7 @@ lint:
 platforms:
   - name: virtualbox-rhel-8
     box: cmihai/rhel-8-base
+    memory: 768
 provisioner:
   name: ansible
   log: True

--- a/roles/virtualbox/tasks/configure.yml
+++ b/roles/virtualbox/tasks/configure.yml
@@ -8,7 +8,9 @@
 
 - name: rebuild kernel modules
   command: /usr/lib/virtualbox/vboxdrv.sh setup
-  when: "'is loaded' not in vboxdrv_status.stdout"
+  when:
+    - "'is loaded' not in vboxdrv_status.stdout"
+    - "'are loaded' not in vboxdrv_status.stdout"
   become: yes
 
 - name: setup VirtualBox user

--- a/roles/virtualbox/tasks/install_RedHat.yml
+++ b/roles/virtualbox/tasks/install_RedHat.yml
@@ -1,7 +1,7 @@
 ---
 # Install VirtualBox on RedHat
 
-- name: setup VirtualBox yum repository on RHEL <= 7
+- name: setup VirtualBox yum repository on RHEL <= 8
   yum_repository:
     name: virtualbox
     description: Oracle Linux / RHEL / CentOS-$releasever / $basearch - VirtualBox
@@ -10,20 +10,7 @@
     gpgcheck: 1
     repo_gpgcheck: 1
     gpgkey: https://www.virtualbox.org/download/oracle_vbox.asc
-  when: ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version']|int <= 7
-  become: yes
-
-# Temporary fix, for RHEL 8 (currently, distribution is not available)
-- name: setup VirtualBox yum repository on RHEL 8 (using Fedora 29 repo)
-  yum_repository:
-    name: virtualbox
-    description: Fedora $releasever - $basearch - VirtualBox
-    baseurl: http://download.virtualbox.org/virtualbox/rpm/fedora/29/$basearch
-    enabled: 1
-    gpgcheck: 1
-    repo_gpgcheck: 1
-    gpgkey: https://www.virtualbox.org/download/oracle_vbox.asc
-  when: ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version']|int == 8
+  when: ansible_facts['distribution'] == "RedHat" and ansible_facts['distribution_major_version']|int <= 8
   become: yes
 
 - name: install VirtualBox

--- a/roles/virtualbox/vars/main.yml
+++ b/roles/virtualbox/vars/main.yml
@@ -32,7 +32,7 @@ vboxdrv_required_packages_centos_7:
 
 vboxdrv_required_packages_rhel_8:
   - binutils
-  - qt
+  - qt5-qtbase
   - gcc
   - make
   - patch


### PR DESCRIPTION
Fixed several items with the RHEL 8 VirtualBox role:
- Remove temporary fix for RHEL 8 VirtualBox configuration since a RHEL 8 RPM is now available. The `when` statement on line 13 could probably also be removed.
- For RHEL 8, the `qt` package is now called `qt5-qtbase`.
- Change the configure task to check for plural modules to make role idempotent.
```
$ /usr/lib/virtualbox/vboxdrv.sh status
VirtualBox kernel modules (vboxdrv, vboxnetflt) are loaded.
```
- The default memory (512 MB) was not enough to rebuild the kernel during the RPM installation of VirtualBox-6.0, and the process would run out of memory. Updating the vagrant VM to use 768 MB resolved the out of memory error and allowed installation to complete successfully.